### PR TITLE
fix sync check ret code 1102

### DIFF
--- a/src/main/java/io/github/biezhi/wechat/api/constant/Constant.java
+++ b/src/main/java/io/github/biezhi/wechat/api/constant/Constant.java
@@ -51,7 +51,7 @@ public interface Constant {
      * webpush url
      */
     List<String> WEB_PUSH_URL = new ArrayList<>(
-            Arrays.asList("webpush.wx2.qq.com", "webpush.wx8.qq.com",
-                    "webpush.wx.qq.com", "webpush.web2.wechat.com", "webpush.web.wechat.com"));
+            Arrays.asList("wx2.qq.com", "wx8.qq.com",
+                    "wx.qq.com", "web2.wechat.com", "web.wechat.com"));
 
 }


### PR DESCRIPTION
网页版微信心跳地址去掉前缀，如果添加前缀，心跳检查会报错